### PR TITLE
feat: make 'session_disconnect_jack' function public

### DIFF
--- a/include/sequoia.h
+++ b/include/sequoia.h
@@ -59,6 +59,7 @@ enum trig_type {TRIG_NULL, TRIG_NOTE, TRIG_CC};
 sq_session_t    sq_session_new(const char*);
 void            sq_session_delete(sq_session_t);
 void            sq_session_delete_recursive(sq_session_t);
+void            sq_session_disconnect_jack(sq_session_t);
 int             sq_session_register_outport(sq_session_t, sq_outport_t);
 int             sq_session_register_inport(sq_session_t, sq_inport_t);
 void            sq_session_add_sequence(sq_session_t, sq_sequence_t);

--- a/src/session.c
+++ b/src/session.c
@@ -56,7 +56,6 @@ static void session_ringbuffer_write(sq_session_t, session_ctrl_msg_t*);
 static void session_reset_frame_counter(sq_session_t );
 static void session_serve_ctrl_msgs(sq_session_t);
 static int session_process(jack_nframes_t, void*);
-static void session_disconnect_jack(sq_session_t);
 static void session_set_bpm_now(sq_session_t, float);
 static void session_add_sequence_now(sq_session_t, sq_sequence_t);
 static void session_rm_sequence_now(sq_session_t, sq_sequence_t);
@@ -133,6 +132,14 @@ void sq_session_delete(sq_session_t sesh) {
     offHeap_delete(sesh->offHeap);
     free(sesh->buf_off);
     free(sesh);
+
+}
+
+void sq_session_disconnect_jack(sq_session_t sesh) {
+
+    if (jack_client_close(sesh->jack_client)) {
+        fprintf(stderr, "sequoia failed to disconnect jack client\n");
+    }
 
 }
 
@@ -384,7 +391,7 @@ void sq_session_delete_recursive(sq_session_t sesh) {
     // recursively frees all the malloc'd memory attributed to the session
 
     sq_session_stop(sesh);
-    session_disconnect_jack(sesh);
+    sq_session_disconnect_jack(sesh);
 
     // sequences
     for (int i=0; i<sesh->nseqs; i++) {
@@ -595,14 +602,6 @@ static int session_process(jack_nframes_t nframes, void *arg) {
     }
 
     return 0;
-
-}
-
-static void session_disconnect_jack(sq_session_t sesh) {
-
-    if (jack_client_close(sesh->jack_client)) {
-        fprintf(stderr, "sequoia failed to disconnect jack client\n");
-    }
 
 }
 


### PR DESCRIPTION
Rationale: the only way to trigger a call to `session_disconnect_jack` and thus properly disconnect from jack from client code currently is to call `sq_session_delete_recursive`. This function, though is not suitable to call from the Python bindings, since it frees memory, to which wrapped Python objects will probably hold references, which is probably also why this function is not wrapped as a method of the `Session` object.

So there is no way to properly disconnect from JACK using the Python bindings, which will usually cause a segmentation fault on program termination, when the session is deleted, but the jack callback is still active.

Accordingly, this PR makes `session_disconnect_jack` "public"  and renames it to `sq_session_disconnect_jack`. A PR to wrap it with the Python bindings follows.

